### PR TITLE
Show 'iss' value, and lint

### DIFF
--- a/chiauth/chiauth.go
+++ b/chiauth/chiauth.go
@@ -28,17 +28,16 @@ type VerificationParams struct {
 
 // NewTokenVerifier returns a token-verifying middleware
 //
-//   tokenVerifier := chiauth.NewTokenVerifier(chiauth.VerificationParams{
-//		Issuers: keyfetch.Whitelist([]string{"https://accounts.google.com"}),
-//		Optional: false,
-//   })
-//   r.Use(tokenVerifier)
+//	  tokenVerifier := chiauth.NewTokenVerifier(chiauth.VerificationParams{
+//			Issuers: keyfetch.Whitelist([]string{"https://accounts.google.com"}),
+//			Optional: false,
+//	  })
+//	  r.Use(tokenVerifier)
 //
-//   r.Post("/api/users/profile", func(w http.ResponseWriter, r *http.Request) {
-//		ctx := r.Context()
-//		jws, ok := ctx.Value(chiauth.JWSKey).(*libauth.JWS)
-//   })
-//
+//	  r.Post("/api/users/profile", func(w http.ResponseWriter, r *http.Request) {
+//			ctx := r.Context()
+//			jws, ok := ctx.Value(chiauth.JWSKey).(*libauth.JWS)
+//	  })
 func NewTokenVerifier(opts VerificationParams) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/chiauth/chiauth.go
+++ b/chiauth/chiauth.go
@@ -45,7 +45,7 @@ func NewTokenVerifier(opts VerificationParams) func(http.Handler) http.Handler {
 
 			token := r.Header.Get("Authorization")
 
-			if "" == token {
+			if token == "" {
 				if opts.Optional {
 					next.ServeHTTP(w, r)
 					return
@@ -60,7 +60,7 @@ func NewTokenVerifier(opts VerificationParams) func(http.Handler) http.Handler {
 			}
 
 			parts := strings.Split(token, " ")
-			if 2 != len(parts) {
+			if len(parts) != 2 {
 				http.Error(
 					w,
 					"Bad Format: expected Authorization header to be in the format of 'Bearer <Token>'",

--- a/chiauth/chiauth.go
+++ b/chiauth/chiauth.go
@@ -51,34 +51,28 @@ func NewTokenVerifier(opts VerificationParams) func(http.Handler) http.Handler {
 					return
 				}
 
-				http.Error(
-					w,
-					"Bad Format: missing Authorization header and 'access_token' query",
-					http.StatusBadRequest,
-				)
+				errmsg := "bad format: missing 'Authorization' header and 'access_token' query"
+				http.Error(w, errmsg, http.StatusBadRequest)
 				return
 			}
 
 			parts := strings.Split(token, " ")
 			if len(parts) != 2 {
-				http.Error(
-					w,
-					"Bad Format: expected Authorization header to be in the format of 'Bearer <Token>'",
-					http.StatusBadRequest,
-				)
+				errmsg := "bad format: expected 'Authorization' header to be in the format of 'Bearer <Token>'"
+				http.Error(w, errmsg, http.StatusBadRequest)
 				return
 			}
 			token = parts[1]
 
 			inspected, err := libauth.VerifyJWT(token, opts.Issuers, r)
 			if nil != err {
-				w.WriteHeader(http.StatusBadRequest)
-				errmsg := "Invalid Token: " + err.Error() + "\n"
-				w.Write([]byte(errmsg))
+				errmsg := "invalid token: " + err.Error()
+				http.Error(w, errmsg, http.StatusBadRequest)
 				return
 			}
 			if !inspected.Trusted {
-				http.Error(w, "Bad Token Signature", http.StatusBadRequest)
+				errmsg := "invalid token: bad signature"
+				http.Error(w, errmsg, http.StatusBadRequest)
 				return
 			}
 

--- a/libauth.go
+++ b/libauth.go
@@ -28,8 +28,9 @@ type IssuerList = keyfetch.Whitelist
 // create a trusted IssuerList of public and/or internal issuer URLs.
 //
 // Example:
-//  OIDC_ISSUERS='https://example.com/ https://therootcompany.github.io/libauth/'
-//  OIDC_ISSUERS_INTERNAL='http://localhost:3000/ http://my-service-name:8080/'
+//
+//	OIDC_ISSUERS='https://example.com/ https://therootcompany.github.io/libauth/'
+//	OIDC_ISSUERS_INTERNAL='http://localhost:3000/ http://my-service-name:8080/'
 func ParseIssuerEnvs(issuersEnvName, internalEnvName string) (IssuerList, error) {
 	if len(issuersEnvName) > 0 {
 		issuersEnvName = oidcIssuersEnv
@@ -49,7 +50,8 @@ func ParseIssuerEnvs(issuersEnvName, internalEnvName string) (IssuerList, error)
 // ParseIssuerListString will Split comma- and/or space-delimited list into a slice
 //
 // Example:
-//  "https://example.com/, https://therootcompany.github.io/libauth/"
+//
+//	"https://example.com/, https://therootcompany.github.io/libauth/"
 func ParseIssuerListString(issuerList string) []string {
 	issuers := []string{}
 

--- a/libauth.go
+++ b/libauth.go
@@ -92,10 +92,10 @@ func VerifyJWS(jws *JWS, issuers IssuerList, r *http.Request) (*JWS, error) {
 
 	_, jwkOK := jws.Header["jwk"]
 	if !jwkOK {
-		if !kidOK || 0 == len(kid) {
+		if !kidOK || len(kid) == 0 {
 			//errs = append(errs, "must have either header.kid or header.jwk")
 			return nil, fmt.Errorf("bad request: missing 'kid' identifier")
-		} else if !issOK || 0 == len(iss) {
+		} else if !issOK || len(iss) == 0 {
 			//errs = append(errs, "payload.iss must exist to complement header.kid")
 			return nil, fmt.Errorf("bad request: payload.iss must exist to complement header.kid")
 		} else {
@@ -117,7 +117,7 @@ func VerifyJWS(jws *JWS, issuers IssuerList, r *http.Request) (*JWS, error) {
 	}
 
 	errs := keypairs.VerifyClaims(pub, &jws.JWS)
-	if 0 != len(errs) {
+	if len(errs) != 0 {
 		strs := []string{}
 		for _, err := range errs {
 			jws.Errors = append(jws.Errors, err)

--- a/libauth.go
+++ b/libauth.go
@@ -68,7 +68,7 @@ func ParseIssuerListString(issuerList string) []string {
 func VerifyJWT(jwt string, issuers IssuerList, r *http.Request) (*JWS, error) {
 	jws := keypairs.JWTToJWS(jwt)
 	if nil == jws {
-		return nil, fmt.Errorf("Bad Request: malformed Authorization header")
+		return nil, fmt.Errorf("bad request: malformed Authorization header")
 	}
 
 	myJws := &JWS{
@@ -94,26 +94,26 @@ func VerifyJWS(jws *JWS, issuers IssuerList, r *http.Request) (*JWS, error) {
 	if !jwkOK {
 		if !kidOK || 0 == len(kid) {
 			//errs = append(errs, "must have either header.kid or header.jwk")
-			return nil, fmt.Errorf("Bad Request: missing 'kid' identifier")
+			return nil, fmt.Errorf("bad request: missing 'kid' identifier")
 		} else if !issOK || 0 == len(iss) {
 			//errs = append(errs, "payload.iss must exist to complement header.kid")
-			return nil, fmt.Errorf("Bad Request: payload.iss must exist to complement header.kid")
+			return nil, fmt.Errorf("bad request: payload.iss must exist to complement header.kid")
 		} else {
 			// TODO beware domain fronting, we should set domain statically
 			// See https://pkg.go.dev/git.rootprojects.org/root/keypairs@v0.6.2/keyfetch
 			// (Caddy does protect against Domain-Fronting by default:
 			//     https://github.com/caddyserver/caddy/issues/2500)
 			if !issuers.IsTrustedIssuer(iss, r) {
-				return nil, fmt.Errorf("Bad Request: 'iss' is not a trusted issuer")
+				return nil, fmt.Errorf("bad request: 'iss' is not a trusted issuer")
 			}
 		}
 		var err error
 		pub, err = keyfetch.OIDCJWK(kid, iss)
 		if nil != err {
-			return nil, fmt.Errorf("Bad Request: 'kid' could not be matched to a known public key: %w", err)
+			return nil, fmt.Errorf("bad request: 'kid' could not be matched to a known public key: %w", err)
 		}
 	} else {
-		return nil, fmt.Errorf("Bad Request: self-signed tokens with 'jwk' are not supported")
+		return nil, fmt.Errorf("bad request: self-signed tokens with 'jwk' are not supported")
 	}
 
 	errs := keypairs.VerifyClaims(pub, &jws.JWS)


### PR DESCRIPTION
The main point of this is to have more specific error messages to avoid wasted time looking into the wrong error.

It also seems that `go fmt` has changed slightly for doc comments, and a few minor linting issues were addressed.